### PR TITLE
PACEtomo, no reliance on per-frame mdoc, GainRef rotation and flip

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.mrc.mdoc filter=lfs diff=lfs merge=lfs -text
+*.mrc filter=lfs diff=lfs merge=lfs -text

--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+# tomotools
+Scripts to make cryo-electron tomography a bit easier
+
+### Currently supported subcommands:
+
+- **batch-prepare-tiltseries**: takes data directories from serialem including frames, mdocs, anchor files, .., aligns the tilt series using MotionCor2, reorders if desired. Supports PACEtomo output files. 
+- **blend-montages**: blends SerialEM montages, writes results to separate folder.
+- **create-movie**: Create a movie from a series of image files. 
+- **cryocare-extract**
+- **cryocare-predict**
+- **cryocare-train**
+- **merge-dboxes**: Very beta, merges Dyname DBoxes
+- **nff-to-amiramesh**
+- **reconstruct**: performs batch reconstruction using imod and/or AreTomo
+
+Full details:
+> tomotools --help  
+> tomotools [subcommand] --help

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='Tomotools',
-    version='0.1.0',
+    version='0.1.1',
     packages=['tomotools', 'tomotools.commands', 'tomotools.utils'],
     install_requires=[
         'Click',

--- a/tomotools/__init__.py
+++ b/tomotools/__init__.py
@@ -5,7 +5,7 @@ from .commands import commands
 
 @click.group()
 def tomotools():
-    click.echo('Tomotools version 0.1.0')
+    click.echo('Tomotools version 0.1.1')
 
 
 for command in commands:

--- a/tomotools/commands/tomography.py
+++ b/tomotools/commands/tomography.py
@@ -246,7 +246,7 @@ def reconstruct(move, local, extra_thickness, bin, sirt, keep_ali_stack, previou
         # Define default thickness as function of pixel size -> always reconstruct 1 um for tomopitch. 
         thickness = str(round(10000 / mdoc['PixelSpacing']))
         full_x, full_y = mdoc['ImageSize']
-        patch_x, patch_y = [round(full_x/1000), round(full_y/1000)]
+        patch_x, patch_y = [str(round(full_x/1000)), str(round(full_y/1000))]
         
         # Generate MRC filenames
         # TODO: Make a class?  

--- a/tomotools/tests/frame_utils_test.py
+++ b/tomotools/tests/frame_utils_test.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Created on Tue Jul 12 18:26:23 2022
+
+@author: bwimmer
+"""
+import unittest
+
+# TODO: test RotationAndFlip (not in file, right output)
+# TODO: test subframe right properties
+# TODO: assert Subframe
+# TODO: implement test reordering (vs. newstack --reorder 1 output)

--- a/tomotools/tests/tomography_test.py
+++ b/tomotools/tests/tomography_test.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Created on Tue Jul 12 18:22:03 2022
+
+@author: bwimmer
+"""
+
+import unittest
+
+# TODO: implement test mdoc reading
+# TODO: implement test anchor / batch detection
+# TODO: implement test for batchfile -> should not fail on empty line // should not change NoneType when file not in list
+# TODO: implement test for previous

--- a/tomotools/utils/frame_utils.py
+++ b/tomotools/utils/frame_utils.py
@@ -33,32 +33,39 @@ def sanitize_subframes_list(subframes: list):
 def sort_subframes_list(subframes: list):
     '''Sorts a list of SubFrames by tilt-angle
     Requires that all SubFrames have a corresponding MDOC file'''
+    # TODO: Check whether reordering can be done w/o subframes
     # Check if the list is a list of subframes
     if not all(isinstance(subframe, SubFrame) for subframe in subframes):
         raise ValueError('sort_subframes_list only supports lists of SubFrames')
     return sorted(subframes, key=lambda subframe: subframe.mdoc['framesets'][0]['TiltAngle'])
 
 
-def frames2stack(subframes: list, stack_path, overwrite_titles=None, skip_evnodd=False):
+def frames2stack(subframes: list, stack_path, full_mdoc: Optional[dict]=None, overwrite_titles=None, skip_evnodd=False):
     # Check if frames and their respective mdoc files exist
     assert_subframes_list(subframes, is_split=False)
 
-    # Merge the mdoc files (except titles, see below)
-    stack_mdoc = {'titles': list(), 'sections': list(), 'framesets': list()}
-    for subframe in subframes:
-        # Update titles and append frameset as new section
-        mdoc = subframe.mdoc
-        stack_mdoc['titles'] = mdoc['titles']
-        stack_mdoc['sections'].append(mdoc['framesets'][0])
-        # Copy global vars (overwrite existing, so again only the last values are kept)
-        for key, value in mdoc.items():
-            if key not in ('framesets', 'titles', 'sections'):
-                stack_mdoc[key] = value
-
-    # Merging the titles is too difficult, I'll just keep the title of the last frame
-    if overwrite_titles is not None:
-        stack_mdoc['titles'] = overwrite_titles
-
+    # If all subframes have their own associated mdoc, merge the mdoc files (except titles, see below)
+    if all(subframe.subframe_mdoc for subframe in subframes):
+        stack_mdoc = {'titles': list(), 'sections': list(), 'framesets': list()}
+        for subframe in subframes:
+            # Update titles and append frameset as new section
+            mdoc = subframe.mdoc
+            stack_mdoc['titles'] = mdoc['titles']
+            stack_mdoc['sections'].append(mdoc['framesets'][0])
+            # Copy global vars (overwrite existing, so again only the last values are kept)
+            for key, value in mdoc.items():
+                if key not in ('framesets', 'titles', 'sections'):
+                    stack_mdoc[key] = value
+    
+        # Merging the titles is too difficult, I'll just keep the title of the last frame
+        if overwrite_titles is not None:
+            stack_mdoc['titles'] = overwrite_titles
+            
+    # Else, just use the input mdoc file
+    # TODO: Implement pixel size change if binned
+    else:
+        stack_mdoc = full_mdoc
+    
     # Build pair(s) of output stack and list of movie sums
     full_stack_basename, full_stack_ext = splitext(stack_path)
     stack_subframes_pairs = [(stack_path, [subframe.path for subframe in subframes])]
@@ -70,7 +77,7 @@ def frames2stack(subframes: list, stack_path, overwrite_titles=None, skip_evnodd
 
     # Run newstack for the full stack and, if desired, the EVN/ODD halves
     for partial_stack_path, partial_stack_subframes in stack_subframes_pairs:
-        subprocess.run(['newstack'] + partial_stack_subframes + [partial_stack_path])
+        subprocess.run(['newstack -q'] + partial_stack_subframes + [partial_stack_path])
         # Update the header of the stack MRC
         with mrcfile.mmap(partial_stack_path, 'r+') as mrc:
             # Copy the first 10 titles into the newly created mrc
@@ -114,6 +121,14 @@ class SubFrame:
     @property
     def is_split(self):
         return isfile(self.path_evn) and isfile(self.path_odd)
+    
+    @property
+    def is_mrc(self):
+        return self.path.endswith('.mrc') or self.path.endswith('.mrcs')
+        
+    @property
+    def subframe_mdoc(self):
+        return isfile(self.mdoc_path)        
 
     def __init__(self, path: str):
         self.path = path
@@ -121,10 +136,14 @@ class SubFrame:
         self._mdoc = None
 
     def files_exist(self, is_split) -> bool:
-        return self.path is not None and isfile(self.path) and isfile(self.mdoc_path) and is_split == self.is_split
+        # TODO: check w/ Moritz whether per-tilt mdoc is really needed
+        #return self.path is not None and isfile(self.path) and isfile(self.mdoc_path) and is_split == self.is_split
+        return self.path is not None and isfile(self.path) and is_split == self.is_split
 
     def assert_files_exist(self, is_split):
-        for file in [self.path, self.mdoc_path] + ([self.path_evn, self.path_odd] if is_split else []):
+        # TODO: check w/ Moritz whether per-tilt mdoc is really needed
+        #for file in [self.path, self.mdoc_path] + ([self.path_evn, self.path_odd] if is_split else []):
+        for file in [self.path] + ([self.path_evn, self.path_odd] if is_split else []):
             if not isfile(file):
                 raise FileNotFoundError(f'File does not exist: {file}')
 
@@ -141,44 +160,58 @@ def motioncor2(subframes: list, output_dir: str, splitsum: bool = False, binning
     if not isdir(tempdir):
         os.makedirs(tempdir)
 
-    # Currently, only zero or one unique gain refs are supported, so check if that's given
-    # Also, use the provided gain ref if it is supplied (option: override_gainref)
-    gain_refs = set([subframe.mdoc['framesets'][0].get('GainReference', None) for subframe in subframes]) \
-        if override_gainref is None \
-        else {override_gainref}
-    if len(gain_refs) != 1:
-        raise Exception(
-            f'Only zero or one unique gain refs are supported, yet {len(gain_refs)} were found in the MDOC files:\n{", ".join(gain_refs)}')
-    # The gain ref should be in the same folder as the input file(s), so check if it's there
-    gain_ref_dm4 = gain_refs.pop()
-    gain_ref_mrc = None
-    if gain_ref_dm4 is not None:
-        gain_ref_dm4 = join(dirname(subframes[0].path), basename(gain_ref_dm4))
-        if not isfile(gain_ref_dm4):
-            raise FileNotFoundError(f'Expected gain reference at {gain_ref_dm4}, aborting')
-        print(f'Found unique gain reference {gain_ref_dm4}, converting to MRC')
-        # The gain ref is saved in dm4 format, convert to MRC for motioncor
-        gain_ref_mrc = splitext(basename(gain_ref_dm4))[0]  # Basename of gain ref without extension and path
-        gain_ref_mrc = join(tempdir, gain_ref_mrc) + '.mrc'
-        subprocess.run(['dm2mrc', gain_ref_dm4, gain_ref_mrc])
+    # Check, if Subframe mdocs are given, if yes check whether zero or one unique gain refs are given
+    # Otherwise, use the provided gain ref if it is supplied (option: override_gainref)
+    # If neither are given, skip gain correction
+    
+    gain_ref_mrc = override_gainref
+    
+    if subframes[0].subframe_mdoc:    
+        gain_refs = set([subframe.mdoc['framesets'][0].get('GainReference', None) for subframe in subframes]) \
+            if override_gainref is None \
+            else {override_gainref}
+        if len(gain_refs) != 1:
+            raise Exception(
+                f'Only zero or one unique gain refs are supported, yet {len(gain_refs)} were found in the MDOC files:\n{", ".join(gain_refs)}')
+        # The gain ref should be in the same folder as the input file(s), so check if it's there
+        gain_ref_dm4 = gain_refs.pop()
+        if gain_ref_dm4 is not None:
+            gain_ref_dm4 = join(dirname(subframes[0].path), basename(gain_ref_dm4))
+            if not isfile(gain_ref_dm4):
+                raise FileNotFoundError(f'Expected gain reference at {gain_ref_dm4}, aborting')
+            print(f'Found unique gain reference {gain_ref_dm4}, converting to MRC')
+            # The gain ref is saved in dm4 format, convert to MRC for motioncor
+            gain_ref_mrc = splitext(basename(gain_ref_dm4))[0]  # Basename of gain ref without extension and path
+            gain_ref_mrc = join(tempdir, gain_ref_mrc) + '.mrc'
+            subprocess.run(['dm2mrc', gain_ref_dm4, gain_ref_mrc])
+    
+    if gain_ref_mrc is not None:
+        print(f'Found gainref override file {gain_ref_mrc}')
+    
     else:
-        print('No gain reference is specified in the MDOC files, continuing without')
+        print('No gain reference is specified in the MDOC files or given as an argument, continuing without gain correction')
 
     # Link the input files to the working dir
     # so that files that should not be motioncor'ed are not
     for subframe in subframes:
         os.symlink(abspath(subframe.path), join(tempdir, basename(subframe.path)))
-
-    command = [mc2_exe,
-               '-InTiff', abspath(tempdir) + path.sep,
-               '-OutMrc', abspath(output_dir) + path.sep,
-               '-Patch', '7', '5',
-               '-Iter', '10',
-               '-Tol', '0.5',
-               '-Kv', '300',
-               '-Ftbin', str(binning),
-               '-Group', str(group),
-               '-Serial', '1']
+        
+        
+        command = [mc2_exe,
+                      '-OutMrc', abspath(output_dir) + path.sep,
+                      '-Patch', '7', '5',
+                      '-Iter', '10',
+                      '-Tol', '0.5',
+                      '-Kv', '300',
+                      '-Ftbin', str(binning),
+                      '-Group', str(group),
+                      '-Serial', '1']
+        
+        if subframe.is_mrc:
+            command += ['-InMrc', abspath(tempdir) + path.sep]
+        else:
+            command += ['-InTiff', abspath(tempdir) + path.sep]
+        
     if gpus is None:
         num_gpus = int(util.gpuinfo()['Attached GPUs'])
         command += ['-Gpu'] + [str(i) for i in range(num_gpus)] if num_gpus > 0 else []
@@ -192,19 +225,22 @@ def motioncor2(subframes: list, output_dir: str, splitsum: bool = False, binning
     print(f'Running motioncor2 with command:\n{" ".join(command)}')
     with open(join(output_dir, 'motioncor2.log'), 'a') as out, open(join(output_dir, 'motioncor2.err'), 'a') as err:
         subprocess.run(command, cwd=tempdir, stdout=out, stderr=err)
-    # Copy the mdoc files to the output dir, rename from .tif.mdoc to .mrc.mdoc
+    
+    # If present, copy the mdoc files to the output dir, rename from .tif.mdoc to .mrc.mdoc
     # they are read and then written and not just copied so that the GainReference field can be removed
     # and the pixel spacing can be adjusted
+    
     for subframe in subframes:
-        # Sanity check: there should be only one frameset
-        if not (isinstance(subframe.mdoc['framesets'], list) and len(subframe.mdoc['framesets']) == 1):
-            raise 'Unexpected MDOC format: tomotools can only handle a single frameset per mdoc'
-        subframe.mdoc['framesets'][0]['PixelSpacing'] *= binning
-        subframe.mdoc['framesets'][0]['Binning'] *= binning
-        if 'GainReference' in subframe.mdoc['framesets'][0]:
-            del subframe.mdoc['framesets'][0]['GainReference']
-        mdocfile.write(subframe.mdoc,
-                       join(output_dir, splitext(splitext(basename(subframe.mdoc_path))[0])[0] + '.mrc.mdoc'))
+        if subframe.subframe_mdoc:
+            # Sanity check: there should be only one frameset
+            if not (isinstance(subframe.mdoc['framesets'], list) and len(subframe.mdoc['framesets']) == 1):
+                raise 'Unexpected MDOC format: tomotools can only handle a single frameset per mdoc'
+            subframe.mdoc['framesets'][0]['PixelSpacing'] *= binning
+            subframe.mdoc['framesets'][0]['Binning'] *= binning
+            if 'GainReference' in subframe.mdoc['framesets'][0]:
+                del subframe.mdoc['framesets'][0]['GainReference']
+            mdocfile.write(subframe.mdoc,
+                           join(output_dir, splitext(splitext(basename(subframe.mdoc_path))[0])[0] + '.mrc.mdoc'))
     rmtree(tempdir)
 
     # Build a list of output files that will be returned to the caller

--- a/tomotools/utils/frame_utils.py
+++ b/tomotools/utils/frame_utils.py
@@ -219,6 +219,11 @@ def motioncor2(subframes: list, output_dir: str, splitsum: bool = False, binning
         command += ['-Gain', abspath(gain_ref_mrc),
                     '-RotGain', str(mcrot), 
                     '-FlipGain', str(mcflip)]
+        
+    # TODO: also use defects file, according to the description on the SerialEM Help:
+    #     clip defect -D defects...txt  fileWithFrames  defects...mrc
+    # where the fileWithFrames is used only to set the size of the output and can be any file of the right X and Y size. 
+    # Then, give file to MotionCor2 as -DefectFile
 
     #print(f'Running motioncor2 with command:\n{" ".join(command)}')
     with open(join(output_dir, 'motioncor2.log'), 'a') as out, open(join(output_dir, 'motioncor2.err'), 'a') as err:

--- a/tomotools/utils/frame_utils.py
+++ b/tomotools/utils/frame_utils.py
@@ -103,7 +103,7 @@ class SubFrame:
 
     @property
     def mdoc(self):
-        if self._mdoc is None:
+        if self._mdoc is None and self.subframe_mdoc:
             self._mdoc = mdocfile.read(self.mdoc_path)
         return self._mdoc
 
@@ -136,13 +136,9 @@ class SubFrame:
         self._mdoc = None
 
     def files_exist(self, is_split) -> bool:
-        # TODO: check w/ Moritz whether per-tilt mdoc is really needed
-        #return self.path is not None and isfile(self.path) and isfile(self.mdoc_path) and is_split == self.is_split
         return self.path is not None and isfile(self.path) and is_split == self.is_split
 
     def assert_files_exist(self, is_split):
-        # TODO: check w/ Moritz whether per-tilt mdoc is really needed
-        #for file in [self.path, self.mdoc_path] + ([self.path_evn, self.path_odd] if is_split else []):
         for file in [self.path] + ([self.path_evn, self.path_odd] if is_split else []):
             if not isfile(file):
                 raise FileNotFoundError(f'File does not exist: {file}')
@@ -163,6 +159,8 @@ def motioncor2(subframes: list, output_dir: str, splitsum: bool = False, binning
     # Check, if Subframe mdocs are given, if yes check whether zero or one unique gain refs are given
     # Otherwise, use the provided gain ref if it is supplied (option: override_gainref)
     # If neither are given, skip gain correction
+    
+    # TODO: Check rotationandflip!
     
     gain_ref_mrc = override_gainref
     
@@ -261,3 +259,15 @@ def motioncor2_executable() -> Optional[str]:
         else:
             warnings.warn(f'MOTIONCOR2_EXECUTABLE is set to "{mc2_exe}", but the file does not exist. Falling back to PATH')
     return shutil.which('motioncor2')
+
+def aretomo_executable() -> Optional[str]:
+    '''The AreTomo executable can be set with one of the following ways (in order of priority):
+    1. Setting the ARETOMO_EXECUTABLE variable to the full path of the executable file
+    2. Putting the appropriate executable into the PATH and renaming it to "aretomo"'''
+    if 'ARETOMO_EXECUTABLE' in os.environ:
+        aretomo_exe = os.environ['ARETOMO_EXECUTABLE']
+        if isfile(aretomo_exe):
+            return aretomo_exe
+        else:
+            warnings.warn(f'ARETOMO_EXECUTABLE is set to "{aretomo_exe}", but the file does not exist. Falling back to PATH')
+    return shutil.which('AreTomo')

--- a/tomotools/utils/mdocfile.py
+++ b/tomotools/utils/mdocfile.py
@@ -31,7 +31,7 @@ def find_relative_path(working_dir, abs_path):
             abs_path = abs_path.split(sep=path.sep, maxsplit=1)[1]
         except IndexError:
             return None
-    print(f'Found subframe path: "{join(working_dir, abs_path)}')
+    #print(f'Found subframe path: "{join(working_dir, abs_path)}')
     return join(working_dir, abs_path)
 
 


### PR DESCRIPTION
This merge includes the following features:
- automated recognition and stashing of PACEtomo targeting files
- supports --reorder flag without per-movie mdoc file (subframe class now has property TiltAngle, taken over from main tiltseries mdoc) -> also added property subframe.subframe_mdoc
- supports both mrc and tif input for motioncor2 (subframe.is_mrc property)
- can translate mdoc property RotationAndFlip to MotionCor2 rotate / flip GainRef, automatically passes this on. 

Problem: without per-subframe mdoc, the GainRef has to be specified manually in all cases using the --gainref flag.