### PR TITLE
Refactoring of reconstruct

### DIFF
--- a/tomotools/commands/preprocessing_reconstruction.py
+++ b/tomotools/commands/preprocessing_reconstruction.py
@@ -224,7 +224,7 @@ def reconstruct(move, local, extra_thickness, bin, sirt, keep_ali_stack, previou
             continue
         else:
             print(f'Found TiltSeries {input_file}.')
-            tiltseries = TiltSeries(input_file)
+            tiltseries = TiltSeries(Path(input_file))
             # Look for MDOC file
             if not path.isfile(tiltseries.mdoc):
                 raise FileNotFoundError(f'No MDOC file found at {tiltseries.mdoc}')

--- a/tomotools/commands/preprocessing_reconstruction.py
+++ b/tomotools/commands/preprocessing_reconstruction.py
@@ -229,7 +229,8 @@ def reconstruct(move, local, extra_thickness, bin, sirt, keep_ali_stack, previou
             if not path.isfile(tiltseries.mdoc):
                 raise FileNotFoundError(f'No MDOC file found at {tiltseries.mdoc}')
             # Check if there are EVN/ODD files for this tiltseries
-            evn_path, odd_path = tiltseries.path.name(f'{tiltseries.path.stem}_EVN.mrc'), tiltseries.path.with_name(f'{tiltseries.path.stem}_ODD.mrc')
+            evn_path = tiltseries.path.with_name(f'{tiltseries.path.stem}_EVN.mrc')
+            odd_path = tiltseries.path.with_name(f'{tiltseries.path.stem}_ODD.mrc')
             if evn_path.is_file() and odd_path.is_file():
                 print(f'Found EVN and ODD stacks for {input_file}.')
                 tiltseries = tiltseries.with_split_files(evn_path, odd_path)

--- a/tomotools/commands/preprocessing_reconstruction.py
+++ b/tomotools/commands/preprocessing_reconstruction.py
@@ -229,7 +229,7 @@ def reconstruct(move, local, extra_thickness, bin, sirt, keep_ali_stack, previou
             if not path.isfile(tiltseries.mdoc):
                 raise FileNotFoundError(f'No MDOC file found at {tiltseries.mdoc}')
             # Check if there are EVN/ODD files for this tiltseries
-            evn_path, odd_path = tiltseries.path.with_stem(f'{tiltseries.path.stem}_EVN'), tiltseries.path.with_stem(f'{tiltseries.path.stem}_ODD')
+            evn_path, odd_path = tiltseries.path.name(f'{tiltseries.path.stem}_EVN.mrc'), tiltseries.path.with_name(f'{tiltseries.path.stem}_ODD.mrc')
             if evn_path.is_file() and odd_path.is_file():
                 print(f'Found EVN and ODD stacks for {input_file}.')
                 tiltseries = tiltseries.with_split_files(evn_path, odd_path)
@@ -255,7 +255,7 @@ def reconstruct(move, local, extra_thickness, bin, sirt, keep_ali_stack, previou
                 
         # Run newstack to exclude tilts 
         if excludetilts is not None:
-            exclude_file = tiltseries.path.with_stem(f'{tiltseries.path.stem}_excludetilts')
+            exclude_file = tiltseries.path.with_name(f'{tiltseries.path.stem}_excludetilts.mrc')
             
             subprocess.run(['newstack',
                             '-in', str(tiltseries.path),

--- a/tomotools/commands/preprocessing_reconstruction.py
+++ b/tomotools/commands/preprocessing_reconstruction.py
@@ -253,9 +253,9 @@ def reconstruct(move, local, extra_thickness, bin, sirt, keep_ali_stack, previou
                 tiltseries.evn_path = tiltseries.evn_path.rename(dir / tiltseries.evn_path.name)
                 tiltseries.odd_path = tiltseries.odd_path.rename(dir / tiltseries.odd_path.name)
                 
-        # Run newstack to exclude tilts 
-        exclude_cmd = ['excludeviews', '-views', excludetilts, '-delete']
+        # Exclude tilts
         if excludetilts is not None:
+            exclude_cmd = ['excludeviews', '-views', excludetilts, '-delete']
             subprocess.run(exclude_cmd + [str(tiltseries.path)])
             print(f'Excluded specified tilts from {tiltseries.path}.')
             if tiltseries.is_split:
@@ -280,6 +280,7 @@ def reconstruct(move, local, extra_thickness, bin, sirt, keep_ali_stack, previou
         # Try to automatically find edges of tomogram
         pitch_mod = tomo_pitch.path.with_name(f'{tiltseries.path.stem}_pitch.mod')
         
+        # The parameters for findsection are taken from the etomo source code
         fs = subprocess.run(['findsection',
                         '-tomo', tomo_pitch.path,
                         '-pitch', pitch_mod,

--- a/tomotools/commands/preprocessing_reconstruction.py
+++ b/tomotools/commands/preprocessing_reconstruction.py
@@ -6,6 +6,7 @@ from os import mkdir
 from os import path
 from os.path import abspath, basename, join
 from pathlib import Path
+from warnings import warn
 
 import click
 import mrcfile
@@ -207,8 +208,11 @@ def reconstruct(move, local, extra_thickness, bin, sirt, keep_ali_stack, previou
         with open(batch_file) as file:
             for line in file:
                 if line != '\n':
-                    l=line.split('\t')
-                    temp={l[0]: l[1].rstrip()}
+                    l = line.rsplit(maxsplit=1)
+                    if len(l) != 2:
+                        warn(f'Skipping invalid line in the batch file: "{line}"')
+                        continue
+                    temp = {l[0]: l[1].rstrip()}
                     ts_info.update(temp)
 
     input_ts = list()

--- a/tomotools/utils/micrograph.py
+++ b/tomotools/utils/micrograph.py
@@ -198,8 +198,8 @@ def defects_tif(gainref: Path, tempdir: Path, template: Path):
     defects_txt = Path(check_defects(gainref))
     defects_tif = defects_txt.with_suffix(".tif")
     if isfile(defects_tif):
-        return defects_tif
         print(f'Found defects file {str(defects_tif)}')
+        return defects_tif
     else:
         subprocess.run(['clip', 'defect', '-D', defects_txt, template, defects_tif])
         print(f'Found defects file and converted to {str(defects_tif)}')

--- a/tomotools/utils/tiltseries.py
+++ b/tomotools/utils/tiltseries.py
@@ -206,7 +206,7 @@ def align_with_areTomo(ts: TiltSeries, local: bool, previous: bool, do_evn_odd: 
     with mrcfile.mmap(ali_stack, mode = 'r+') as mrc:
            mrc.voxel_size = str(angpix)
            mrc.update_header_stats()
-    
+        
     print(f'Done aligning {ts.path.stem} with AreTomo.')
 
     if do_evn_odd and ts.is_split:
@@ -232,9 +232,15 @@ def align_with_areTomo(ts: TiltSeries, local: bool, previous: bool, do_evn_odd: 
         with mrcfile.mmap(ali_stack_odd, mode = 'r+') as mrc:
             mrc.voxel_size = str(angpix)
             mrc.update_header_stats()
-
+        
+        os.remove(tlt_file)
+        os.remove(ali_stack_evn.with_name(f'{ali_stack_evn.stem}.tlt'))
+        os.remove(ali_stack_odd.with_name(f'{ali_stack_odd.stem}.tlt'))
+        
         print(f'Done aligning ENV and ODD stacks for {ts.path.stem} with AreTomo.')
         return TiltSeries(ali_stack).with_split_files(ali_stack_evn, ali_stack_odd).with_mdoc(orig_mdoc)
+    
+    os.remove(tlt_file)
     
     return TiltSeries(ali_stack).with_mdoc(orig_mdoc)
 

--- a/tomotools/utils/tomogram.py
+++ b/tomotools/utils/tomogram.py
@@ -227,6 +227,7 @@ class Tomogram:
                 os.remove(full_rec_odd)
                 return Tomogram(final_rec).with_split_files(final_rec_evn, final_rec_odd)
             
+            os.remove(full_rec)
             return Tomogram(final_rec)
             
         return Tomogram(full_rec)


### PR DESCRIPTION
I made quite a few changes. In my case they don't break anything:

- the batch-file doesn't have to be tab-separated but can also be space separated
- the input files all converted to TiltSeries objects at the start
- shutil.move() -> Path.rename()
- newstack -exclude -> excludeviews -views (this is the way etomo does it, original TS can be restored with excludeviews -restore)

What I'd like to change in the reconstruct function still:
- remove all the intermediate files like _ali_filtered.mrc and the like
- optional: if the user doesn't specify a batch-file, they could be asked for views to exclude for each TS in an interactive manner like:
`Enter views to exclude for TS_01 [same format as in imod/etomo, enter for none, "skip" to skip this step for all TS`