### PR TITLE
Serialem navigator function

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ tomotools [subcommand] --help
 - **merge-dboxes**: Very beta, merges Dynamo DBoxes.
 
 ### Other
+- **semnavigator**: Display SerialEM navigator files to find back you tomogram positions
 - **create-movie**: Create a movie from a series of image files.
 - **nff-to-amiramesh**
 - **update**: Automatically pulls the most recent version from GitHub and runs pip install --upgrade on it.

--- a/tomotools/commands/serialem.py
+++ b/tomotools/commands/serialem.py
@@ -9,6 +9,7 @@ from tomotools.utils.serialem_navigator import SEMNavigator
 @click.command()
 @click.argument('path', type=click.Path(exists=True, dir_okay=False))
 def semnavigator(path):
+    """Open a SerialEM navigator (.nav) file in a small graphical browser"""
     nav = SEMNavigator.read(path)
     fig, ax = plt.subplots()
     all_ptsx, all_ptsy = list(), list()

--- a/tomotools/commands/serialem.py
+++ b/tomotools/commands/serialem.py
@@ -1,0 +1,33 @@
+import click
+import matplotlib.patches as patches
+import matplotlib.pyplot as plt
+from matplotlib.path import Path
+
+from tomotools.utils.serialem_navigator import SEMNavigator
+
+
+@click.command()
+@click.argument('path', type=click.Path(exists=True, dir_okay=False))
+def semnavigator(path):
+    nav = SEMNavigator.read(path)
+    fig, ax = plt.subplots()
+    all_ptsx, all_ptsy = list(), list()
+    for item in nav.items:
+        ptsx_str, ptsy_str = item.get('PtsX'), item.get('PtsY')
+        if ptsx_str is None or ptsy_str is None:
+            continue
+        ptsx = [float(x) for x in ptsx_str.split()]
+        ptsy = [float(y) for y in ptsy_str.split()]
+        if len(ptsx) != len(ptsy):
+            raise AttributeError(f'PtsX and PtsY have unequal length in item {item.id}')
+        all_ptsx += ptsx
+        all_ptsy += ptsy
+        vertices = list(zip(ptsx, ptsy))
+        codes = [Path.MOVETO] + [Path.LINETO] * (len(vertices) - 1)
+        path = Path(vertices, codes)
+        patch = patches.PathPatch(path, facecolor='none', lw=2)
+        ax.add_patch(patch)
+        ax.text(*vertices[0], item)
+    ax.set_xlim(min(all_ptsx) * 1.1, max(all_ptsx) * 1.1)
+    ax.set_ylim(min(all_ptsy) * 1.1, max(all_ptsy) * 1.1)
+    plt.show()

--- a/tomotools/utils/serialem_navigator.py
+++ b/tomotools/utils/serialem_navigator.py
@@ -1,0 +1,61 @@
+import os
+from typing import Tuple
+
+
+class SEMNavigator:
+    def __init__(self):
+        self.header = dict()
+        self.items = list()
+
+    @staticmethod
+    def read(path: os.PathLike) -> 'SEMNavigator':
+        nav = SEMNavigator()
+        with open(path) as file:
+            for line in file:
+                if line.isspace() or len(line) == 0:
+                    continue
+                elif line.startswith('['):
+                    index = _parse_header(line)
+                    nav_item = NavigatorItem(index)
+                    line = next(file)
+                    while not (line.isspace() or len(line) == 0):
+                        key, value = _parse_field(line)
+                        nav_item[key] = value
+                        try:
+                            line = next(file)
+                        except StopIteration:
+                            break
+                    nav.items.append(nav_item)
+                else:
+                    key, value = _parse_field(line)
+                    nav.header[key] = value
+            return nav
+
+
+class NavigatorItem(dict):
+    def __repr__(self):
+        # Best: return Note
+        note = self.get('Note')
+        if note is not None:
+            return note
+        # Second best: return MapFile
+        map_file = self.get('MapFile')
+        if map_file is not None:
+            return map_file.rsplit('\\', maxsplit=1)[-1]
+        # Fallback: return id
+        return self.id
+
+    def __init__(self, id: str):
+        super().__init__()
+        self.id = id
+
+
+def _parse_header(line: str) -> str:
+    line = line.strip()[1:-1]
+    _, value = _parse_field(line)
+    return value
+
+
+def _parse_field(line: str) -> Tuple[str, str]:
+    key, value = line.split(' = ', maxsplit=1)
+    return key.strip(), value.strip()


### PR DESCRIPTION
I created a small browser for SerialEM navigator files with a very simple matplotlib GUI, kind of similar to how it is currently done in PACEtomo. Helps to find back tomogram positions on your maps, especially for correlative approaches.

There is no functionality for loading images. Right now it just displays a rectangle and either the note, the mapfile or just the item ID (in this order).